### PR TITLE
Add the proper intents so we see new members join

### DIFF
--- a/butterbean.py
+++ b/butterbean.py
@@ -19,8 +19,12 @@ from config import config
 #-----------Buttons!-----------#
 bovontoSchedule = False
 
+#-----------Get privileged "members" intent so we can greet new users -----------#
+intents = discord.Intents.default()
+intents.members = True
+
 #-----------Intializing functions-----------#
-client = commands.Bot(command_prefix='!', description='Butterborg is online.', add=True)
+client = commands.Bot(command_prefix='!', description='Butterborg is online.', add=True, intents=intents)
 
 #-----------Intializing ready-----------#   
 @client.event


### PR DESCRIPTION
This, along with granting the permission for the intent in the dev portal, should solve the problem with the bot no longer seeing new members joining. Did it stop working about 20 days ago? Because that's when the example code in the discordpy repo was last changed, too.