### PR TITLE
Miscellaneous command fixes

### DIFF
--- a/app/butterbean.py
+++ b/app/butterbean.py
@@ -17,7 +17,10 @@ from modules.config import config
 bovontoSchedule = False
 
 #-----------Get privileged intents so we can be in compliance with the API  -----------#
-intents = discord.Intents(messages= True, members= True,message_content= True )
+intents = discord.Intents.default()
+intents.messages = True
+intents.members = True
+intents.message_content = True  
 
 #-----------Intializing functions-----------#
 client = commands.Bot(command_prefix='!', description='Butterborg is online.', add=True, intents=intents)

--- a/app/butterbean.py
+++ b/app/butterbean.py
@@ -223,7 +223,7 @@ async def listroles(ctx):
 
 #Creates a looped task to execute the Bovonto pitches regularly
 while bovontoSchedule == True:
-   client.loop.create_task(makePitch())
+   client.loop.create_task(makePitch(client))
 
 #---------------- Tarot functions ----------------
 # single card draw

--- a/app/butterbean.py
+++ b/app/butterbean.py
@@ -215,10 +215,7 @@ async def leave(ctx, oldRole):
 #Lists unformatted all roles.  
 @client.command()
 async def listroles(ctx):
-    rolesStr = ''
-    roles = ctx.guild.roles
-    for i in roles:
-        rolesStr += " " + str(i) +","
+    rolesStr = ', '.join(map(lambda r: str(r), ctx.guild.roles))
     await ctx.send(rolesStr)
 
 #Creates a looped task to execute the Bovonto pitches regularly

--- a/app/modules/bobross.py
+++ b/app/modules/bobross.py
@@ -1,4 +1,7 @@
-#import random, discord, asyncio
+
+import random
+import discord
+
 def pickRandomLine(name, icon, lines):
     randLine = random.randint(0, len(lines) - 1)
     line = lines[randLine]

--- a/app/modules/bovonto.py
+++ b/app/modules/bovonto.py
@@ -1,4 +1,8 @@
-#import random, discord, asyncio
+
+import random
+import discord
+import asyncio
+
 def pickRandomLine(name, icon, lines):
     randLine = random.randint(0, len(lines) - 1)
     line = lines[randLine]
@@ -6,7 +10,7 @@ def pickRandomLine(name, icon, lines):
     e.set_author(name=name, icon_url=icon)
     return e
 
-async def makePitch():
+async def makePitch(client):
     #Sets up status as ready
     await client.wait_until_ready()
     #Defines channels to send to (TOKENIZE THIS ASAP)


### PR DESCRIPTION
Fixes `!listroles`, `!bovonto` and `!bobross` and makes the list of roles returned by `!listroles` slightly prettier (removing trailing comma).

`!listroles` was probably broken by a change in how discord.py handles intents (and/or the constructor for intents didn't like one of the parameters), so the list of roles provided in the command's context was empty due to lack of permissions, and switching to the preferred code from the current docs fixed that.

`!bovonto` needed some imports fixed and now gets the Discord client object passed as a parameter, since it uses that directly.

`!bobross` likewise just needed its imports back.